### PR TITLE
Remove main library import logging configuration/setup

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -12,7 +12,6 @@ import os
 import re
 
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Apps using this library should configure logging however
they want, and not have pykeepass try to do it when they
import pykeepass

Fixes issue #3