### PR TITLE
Set expires parameter to False by default

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -24,7 +24,7 @@ reserved_keys = [
 class Entry(BaseElement):
 
     def __init__(self, title=None, username=None, password=None, url=None,
-                 notes=None, tags=None, expires=None, expiration=None,
+                 notes=None, tags=None, expires=False, expiration=None,
                  icon=None, element=None):
         if element is None:
             element = Element('Entry')


### PR DESCRIPTION
In order to bypass https://github.com/pschmitt/pykeepass/issues/14 we
set expires to False. This allows faulty versions of KeePassX to open
files with passwords added by pykeepass.