### PR TITLE
Added set_password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,3 +190,16 @@ Adding Groups
    # save the database
    >>> kp.save()
        
+Miscellaneous
+-------------
+**read** (filename, password=None, keyfile=None)
+
+where ``filename``, ``password``, and ``keyfile`` are strings.  ``filename`` is the path to the database, ``password`` is the master password string, and ``keyfile`` is the path to the database keyfile.  At least one of ``password`` and ``keyfile`` is required.
+
+**save** (filename=None)
+
+where ``filename`` is the path of the file to save to.  If ``filename`` is not given, the path given in ``read`` will be used.
+
+**set_password** (password)
+
+set a master password on the database.  ``password`` is a string.

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,6 @@ pykeepass
 
 This library allows you to write entries to a KeePass database
 
-*pykeepass does not currently support Python 3*
-
 Simple Example
 --------------
 .. code:: python
@@ -36,6 +34,7 @@ Simple Example
 
    # create a new entry
    >>> kp.add_entry(group, 'gmail', 'myusername', 'myPassw0rdXX')
+   [Entry: "email/gmail"]
 
    # save database
    >>> kp.save()
@@ -46,12 +45,17 @@ Finding Entries
 
 The supported find commands are listed below
 
-* **find_entries_by_title** (title, regex=False, tree=None, history=False, first=False)
-* **find_entries_by_username** (username, regex=False, tree=None, history=False, first=False)
-* **find_entries_by_password** (password, regex=False, tree=None, history=False, first=False)
-* **find_entries_by_url** (url, regex=False, tree=None, history=False, first=False)
-* **find_entries_by_notes** (notes, regex=False, tree=None, history=False, first=False)
-* **find_entries_by_path** (path, regex=False, tree=None, history=False, first=False)
+**find_entries_by_title** (title, regex=False, tree=None, history=False, first=False)
+
+**find_entries_by_username** (username, regex=False, tree=None, history=False, first=False)
+
+**find_entries_by_password** (password, regex=False, tree=None, history=False, first=False)
+
+**find_entries_by_url** (url, regex=False, tree=None, history=False, first=False)
+
+**find_entries_by_notes** (notes, regex=False, tree=None, history=False, first=False)
+
+**find_entries_by_path** (path, regex=False, tree=None, history=False, first=False)
 
 where ``title``, ``username``, ``password``, ``url``, ``notes`` and ``path`` are strings.  These functions have an optional ``regex`` boolean argument which means to interpret the string as an `XSLT style`_ regular expression.
 
@@ -60,10 +64,11 @@ where ``title``, ``username``, ``password``, ``url``, ``notes`` and ``path`` are
 The ``history`` (default ``False``) boolean controls whether history entries should be included in the search results.
 
 The ``first`` (default ``False``) boolean controls whether to return the first matched item, or a list of matched items.
+
 * if ``first=False``, the function returns a list of ``Entry`` s or ``[]`` if there are no matches
 * if ``first=True``, the function returns the first ``Entry`` match, or ``None`` if there are no matches
 
-* **entries**
+**entries**
 
 a flattened list of all entries in the database
 
@@ -88,22 +93,24 @@ a flattened list of all entries in the database
 Finding Groups
 ----------------------
 
-* **find_groups_by_name** (name, tree=None, regex=False, first=False)
-* **find_groups_by_path** (path, tree=None, regex=False, first=False)
+**find_groups_by_name** (name, tree=None, regex=False, first=False)
+
+**find_groups_by_path** (path, tree=None, regex=False, first=False)
 
 where ``name`` and ``path`` are strings.  These functions have an optional ``regex`` boolean argument which means to interpret the string as an `XSLT style`_ regular expression.
 
 .. _XSLT style: https://www.xml.com/pub/a/2003/06/04/tr.html
 
 The ``first`` (default ``False``) boolean controls whether to return the first matched item, or a list of matched items.
+
 * if ``first=False``, the function returns a list of ``Group`` s or ``[]`` if there are no matches
 * if ``first=True``, the function returns the first ``Group`` match, or ``None`` if there are no matches
 
-* **root_group**
+**root_group**
 
 the ``Root`` group to the database
 
-* **groups**
+**groups**
 
 a flattened list of all groups in the database
 
@@ -130,11 +137,10 @@ a flattened list of all groups in the database
 
 Adding Entries
 --------------
-* **add_entry** (destination_group, title, username, password, url=None, notes=None, tags=None, icon=None, force_creation=False)
+**add_entry** (destination_group, title, username, password, url=None, notes=None, tags=None, icon=None, force_creation=False)
 
-This function adds a new entry to the existing group ``destination_group``.
-
-``destination_group`` is a ``Group`` instance.  ``title``, ``username``, ``password``, ``url``, ``notes``, ``tags``, ``icon`` are strings.
+**delete_entry** (entry)
+``destination_group`` is a ``Group`` instance.  ``entry`` is an ``Entry`` instance. ``title``, ``username``, ``password``, ``url``, ``notes``, ``tags``, ``icon`` are strings.
 
 .. code:: python
 
@@ -144,23 +150,41 @@ This function adds a new entry to the existing group ``destination_group``.
 
    # add a new entry to the social group
    >>> group = find_groups_by_name('social', first=True)
-   >>> kp.add_entry(group, 'testing', 'foo_user', 'passw0rd')
+   >>> entry = kp.add_entry(group, 'testing', 'foo_user', 'passw0rd')
    Entry: "testing"
+   
+   # save the database
+   >>> kp.save()
+   
+   # delete an entry
+   >>> kp.delete_entry(entry)
+   
+   # save the database
+   >>> kp.save()
 
 Adding Groups
 --------------
-* **add_group** (destination_group, group_name)
+**add_group** (destination_group, group_name)
 
-This function adds a new group to the existing group ``destination_group``.
+**delete_group** (group)
 
-``destination_group`` is a ``Group`` instance.  ``group_name`` is a string.
+``destination_group`` and ``group`` are instances of ``Group``.  ``group_name`` is a string
 
 .. code:: python
 
    # add a new group to the Root group
    >>> group = kp.add_group(kp.root_group, 'social')
 
-   # add a new subgroup
+   # add a new group
    >>> kp.add_group(group, 'gmail')
    Group: "social/gmail"
+   
+   # save the database
+   >>> kp.save()
+   
+   # delete a group
+   >>> kp.delete_group(group)
+   
+   # save the database
+   >>> kp.save()
        

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ pykeepass
 
 This library allows you to write entries to a KeePass database
 
+*pykeepass does not currently support Python 3*
+
 Simple Example
 --------------
 .. code:: python
@@ -175,7 +177,7 @@ Adding Groups
    # add a new group to the Root group
    >>> group = kp.add_group(kp.root_group, 'social')
 
-   # add a new group
+   # add a new group to the social group
    >>> kp.add_group(group, 'gmail')
    Group: "social/gmail"
    

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Simple Example
 
    # create a new entry
    >>> kp.add_entry(group, 'gmail', 'myusername', 'myPassw0rdXX')
-   [Entry: "email/gmail"]
+   Entry: "email/gmail"
 
    # save database
    >>> kp.save()

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -204,7 +204,7 @@ class PyKeePass():
             else:
                 res = [x for x in group.entries if x.title == entry_title]
         else:
-            return None
+            return
 
         # return first object in list or None
         if first:

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -9,13 +9,12 @@ from group import Group
 import libkeepass
 import logging
 import os
-import re
 
 
 logger = logging.getLogger(__name__)
 
 
-class PyKeePass(object):
+class PyKeePass():
 
     def __init__(self, filename, password=None, keyfile=None):
         self.kdb_filename = filename
@@ -77,8 +76,7 @@ class PyKeePass(object):
 
     #---------- Groups ----------
 
-    def find_groups_by_name(self, group_name, tree=None, regex=False,
-                            first=False):
+    def find_groups_by_name(self, group_name, tree=None, regex=False, first=False):
         if regex:
             xp = './/Group/Name[re:test(text(), "{}")]/..'.format(group_name)
         else:
@@ -91,10 +89,8 @@ class PyKeePass(object):
 
         return res
 
-    def find_groups_by_path(self, group_path_str=None, regex=False, tree=None,
-                            first=False):
-        logger.info('Looking for group {}'.format(
-            group_path_str if group_path_str else 'Root'))
+    def find_groups_by_path(self, group_path_str=None, regex=False, tree=None, first=False):
+        logger.info('Looking for group {}'.format(group_path_str if group_path_str else 'Root'))
         xp = '/KeePassFile/Root/Group'
 
         # remove leading and trailing /
@@ -123,10 +119,12 @@ class PyKeePass(object):
 
         return group
 
+    def delete_group(self, group):
+        group.delete()
+
     #---------- Entries ----------
 
-    def __find_entry_by(self, key, value, regex=False, tree=None,
-                        history=False, first=False):
+    def __find_entry_by(self, key, value, regex=False, tree=None, history=False, first=False):
         if regex:
             xp = './/Entry/String/Key[text()="{}"]/../Value[re:test(text(), "{}")]/../..'.format(
                 key, value
@@ -145,8 +143,7 @@ class PyKeePass(object):
 
         return res
 
-    def find_entries_by_title(self, title, regex=False, tree=None,
-                              history=False, first=False):
+    def find_entries_by_title(self, title, regex=False, tree=None, history=False, first=False):
         return self.__find_entry_by(
             key='Title',
             value=title,
@@ -156,8 +153,7 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_username(self, username, regex=False, tree=None,
-                                 history=False, first=False):
+    def find_entries_by_username(self, username, regex=False, tree=None, history=False, first=False):
         return self.__find_entry_by(
             key='UserName',
             value=username,
@@ -167,8 +163,7 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_password(self, password, regex=False, tree=None,
-                                 history=False, first=False):
+    def find_entries_by_password(self, password, regex=False, tree=None, history=False, first=False):
         return self.__find_entry_by(
             key='Password',
             value=password,
@@ -178,8 +173,7 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_url(self, url, regex=False, tree=None,
-                            history=False, first=False):
+    def find_entries_by_url(self, url, regex=False, tree=None, history=False, first=False):
         return self.__find_entry_by(
             key='URL',
             value=url,
@@ -189,8 +183,7 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_notes(self, notes, regex=False, tree=None,
-                              history=False, first=False):
+    def find_entries_by_notes(self, notes, regex=False, tree=None, history=False, first=False):
         return self.__find_entry_by(
             key='Notes',
             value=notes,
@@ -200,19 +193,18 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_path(self, path, regex=False, tree=None,
-                             history=False, first=False):
+    def find_entries_by_path(self, path, regex=False, tree=None, history=False, first=False):
         entry_title = os.path.basename(path)
         group_path = os.path.dirname(path)
-        group = self.find_groups_by_path(
-            group_path, tree=tree, regex=regex, first=True
-        )
+        group = self.find_groups_by_path(group_path, tree=tree, regex=regex, first=True)
+
         if group is not None:
             if regex:
-                res = [x for x in group.entries if \
-                       re.match(entry_title, x.title)]
+                res = [x for x in group.entries if re.match(entry_title, x.title)]
             else:
                 res = [x for x in group.entries if x.title == entry_title]
+        else:
+            return None
 
         # return first object in list or None
         if first:
@@ -223,13 +215,15 @@ class PyKeePass(object):
     def add_entry(self, destination_group, title, username,
                   password, url=None, notes=None,
                   tags=None, icon=None, force_creation=False):
+
         entries = self.find_entries_by_title(
-            tree=destination_group._element, title=title
+            tree=destination_group._element,
+            title=title,
         )
         if entries and not force_creation:
             logger.warning(
                 'An entry "{}" already exists in "{}". Updating it.'.format(
-                    title, destination_group
+                    title, group_path
                 )
             )
             entry = entries[0]
@@ -262,3 +256,6 @@ class PyKeePass(object):
             destination_group.append(entry)
 
         return entry
+
+    def delete_entry(self, entry):
+        entry.delete()

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -9,6 +9,7 @@ from group import Group
 import libkeepass
 import logging
 import os
+import re
 
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,8 @@ class PyKeePass(object):
 
     #---------- Groups ----------
 
-    def find_groups_by_name(self, group_name, tree=None, regex=False, first=False):
+    def find_groups_by_name(self, group_name, regex=False, tree=None,
+                            first=False):
         if regex:
             xp = './/Group/Name[re:test(text(), "{}")]/..'.format(group_name)
         else:
@@ -89,8 +91,10 @@ class PyKeePass(object):
 
         return res
 
-    def find_groups_by_path(self, group_path_str=None, regex=False, tree=None, first=False):
-        logger.info('Looking for group {}'.format(group_path_str if group_path_str else 'Root'))
+    def find_groups_by_path(self, group_path_str=None, regex=False, tree=None,
+                            first=False):
+        logger.info('Looking for group {}'.format(
+            group_path_str if group_path_str else 'Root'))
         xp = '/KeePassFile/Root/Group'
 
         # remove leading and trailing /
@@ -124,7 +128,8 @@ class PyKeePass(object):
 
     #---------- Entries ----------
 
-    def __find_entry_by(self, key, value, regex=False, tree=None, history=False, first=False):
+    def __find_entry_by(self, key, value, regex=False, tree=None,
+                        history=False, first=False):
         if regex:
             xp = './/Entry/String/Key[text()="{}"]/../Value[re:test(text(), "{}")]/../..'.format(
                 key, value
@@ -143,7 +148,8 @@ class PyKeePass(object):
 
         return res
 
-    def find_entries_by_title(self, title, regex=False, tree=None, history=False, first=False):
+    def find_entries_by_title(self, title, regex=False, tree=None,
+                              history=False, first=False):
         return self.__find_entry_by(
             key='Title',
             value=title,
@@ -153,7 +159,8 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_username(self, username, regex=False, tree=None, history=False, first=False):
+    def find_entries_by_username(self, username, regex=False, tree=None,
+                                 history=False, first=False):
         return self.__find_entry_by(
             key='UserName',
             value=username,
@@ -163,7 +170,8 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_password(self, password, regex=False, tree=None, history=False, first=False):
+    def find_entries_by_password(self, password, regex=False, tree=None,
+                                 history=False, first=False):
         return self.__find_entry_by(
             key='Password',
             value=password,
@@ -173,7 +181,8 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_url(self, url, regex=False, tree=None, history=False, first=False):
+    def find_entries_by_url(self, url, regex=False, tree=None, history=False,
+                            first=False):
         return self.__find_entry_by(
             key='URL',
             value=url,
@@ -183,7 +192,8 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_notes(self, notes, regex=False, tree=None, history=False, first=False):
+    def find_entries_by_notes(self, notes, regex=False, tree=None, history=False,
+                              first=False):
         return self.__find_entry_by(
             key='Notes',
             value=notes,
@@ -193,10 +203,14 @@ class PyKeePass(object):
             first=first
         )
 
-    def find_entries_by_path(self, path, regex=False, tree=None, history=False, first=False):
+    def find_entries_by_path(self, path, regex=False, tree=None, history=False,
+                             first=False):
         entry_title = os.path.basename(path)
         group_path = os.path.dirname(path)
-        group = self.find_groups_by_path(group_path, tree=tree, regex=regex, first=True)
+        group = self.find_groups_by_path(group_path,
+                                         tree=tree,
+                                         regex=regex,
+                                         first=True)
 
         if group is not None:
             if regex:

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -38,6 +38,13 @@ class PyKeePass(object):
         self.kdb.write_to(outfile)
         return outfile
 
+    # set the master password
+    def set_password(self, password):
+        if password:
+            self.kdb.keys[0] = libkeepass.crypto.sha256(password.encode('utf-8'))
+        else:
+            logger.error("You must specify a password")
+
     @property
     def root_group(self):
         return self.find_groups_by_path('', tree=None, first=True)

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -14,7 +14,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class PyKeePass():
+class PyKeePass(object):
 
     def __init__(self, filename, password=None, keyfile=None):
         self.kdb_filename = filename
@@ -223,7 +223,7 @@ class PyKeePass():
         if entries and not force_creation:
             logger.warning(
                 'An entry "{}" already exists in "{}". Updating it.'.format(
-                    title, group_path
+                    title, destination_group
                 )
             )
             entry = entries[0]

--- a/pykeepass/tests.py
+++ b/pykeepass/tests.py
@@ -21,52 +21,52 @@ class EntryFunctionTests(unittest.TestCase):
 
     # get some things ready before testing
     def setUp(self):
-        self.pk = pykeepass.PyKeePass('./test.kdbx', password='passw0rd')
+        self.kp = pykeepass.PyKeePass('./test.kdbx', password='passw0rd')
 
     #---------- Finding entries -----------
 
     def test_find_entries_by_title(self):
-        results = self.pk.find_entries_by_title('root_entry')
+        results = self.kp.find_entries_by_title('root_entry')
         self.assertEqual(len(results), 1)
-        results = self.pk.find_entries_by_title('root_entry', first=True)
+        results = self.kp.find_entries_by_title('root_entry', first=True)
         self.assertEqual('root_entry', results.title)
 
     def test_find_entries_by_username(self):
-        results = self.pk.find_entries_by_username('foobar_user')
+        results = self.kp.find_entries_by_username('foobar_user')
         self.assertEqual(len(results), 2)
-        results = self.pk.find_entries_by_username('foobar_user', first=True)
+        results = self.kp.find_entries_by_username('foobar_user', first=True)
         self.assertEqual('foobar_user', results.username)
 
     def test_find_entries_by_password(self):
-        results = self.pk.find_entries_by_password('passw0rd')
+        results = self.kp.find_entries_by_password('passw0rd')
         self.assertEqual(len(results), 2)
-        results = self.pk.find_entries_by_password('passw0rd', first=True)
+        results = self.kp.find_entries_by_password('passw0rd', first=True)
         self.assertEqual('passw0rd', results.password)
 
     def test_find_entries_by_url(self):
-        results = self.pk.find_entries_by_url('http://example.com')
+        results = self.kp.find_entries_by_url('http://example.com')
         self.assertEqual(len(results), 2)
-        results = self.pk.find_entries_by_url('http://example.com', first=True)
+        results = self.kp.find_entries_by_url('http://example.com', first=True)
         self.assertEqual('http://example.com', results.url)
 
     def test_find_entries_by_notes(self):
-        results = self.pk.find_entries_by_notes('entry notes')
+        results = self.kp.find_entries_by_notes('entry notes')
         self.assertEqual(len(results), 2)
-        results = self.pk.find_entries_by_notes('entry notes', first=True)
+        results = self.kp.find_entries_by_notes('entry notes', first=True)
         self.assertEqual('entry notes', results.notes)
 
     def test_find_entries_by_path(self):
-        results = self.pk.find_entries_by_path('foobar_group/group_entry')
+        results = self.kp.find_entries_by_path('foobar_group/group_entry')
         self.assertEqual(len(results), 1)
-        results = self.pk.find_entries_by_path('foobar_group/group_entry', first=True)
+        results = self.kp.find_entries_by_path('foobar_group/group_entry', first=True)
         self.assertIsInstance(results, Entry)
         self.assertEqual('group_entry', results.title)
 
     #---------- Adding/Deleting entries -----------
 
-    def test_add_entry(self):
+    def test_add_delete_entry(self):
         unique_str = 'test_add_entry_'
-        entry = self.pk.add_entry(self.pk.root_group,
+        entry = self.kp.add_entry(self.kp.root_group,
                                   unique_str+'title',
                                   unique_str+'user',
                                   unique_str+'pass',
@@ -74,9 +74,9 @@ class EntryFunctionTests(unittest.TestCase):
                                   unique_str+'notes',
                                   unique_str+'tags',
                                   icons.KEY)
-        results = self.pk.find_entries_by_title(unique_str+'title')
+        results = self.kp.find_entries_by_title(unique_str+'title')
         self.assertEqual(len(results), 1)
-        results = self.pk.find_entries_by_title(unique_str+'title', first=True)
+        results = self.kp.find_entries_by_title(unique_str+'title', first=True)
 
         self.assertEqual(results.title, unique_str+'title')
         self.assertEqual(results.username, unique_str+'user')
@@ -86,44 +86,53 @@ class EntryFunctionTests(unittest.TestCase):
         self.assertEqual(results.tags, [unique_str+'tags'])
         self.assertEqual(results.icon, icons.KEY)
 
+        self.kp.delete_entry(entry)
+        results = self.kp.find_entries_by_title(unique_str+'title', first=True)
+        self.assertIsNone(results)
+
 
 class GroupFunctionTests(unittest.TestCase):
 
     # get some things ready before testing
     def setUp(self):
-        self.pk = pykeepass.PyKeePass('./test.kdbx', password='passw0rd')
+        self.kp = pykeepass.PyKeePass('./test.kdbx', password='passw0rd')
 
     #---------- Finding groups -----------
 
     def test_find_groups_by_name(self):
-        results = self.pk.find_groups_by_name('subgroup')
+        results = self.kp.find_groups_by_name('subgroup')
         self.assertEqual(len(results), 1)
-        results = self.pk.find_groups_by_name('subgroup', first=True)
+        results = self.kp.find_groups_by_name('subgroup', first=True)
         self.assertEqual(results.name, 'subgroup')
 
     def test_find_groups_by_path(self):
-        results = self.pk.find_groups_by_path('/foobar_group/subgroup')
+        results = self.kp.find_groups_by_path('/foobar_group/subgroup')
         self.assertIsInstance(results[0], Group)
-        results = self.pk.find_groups_by_path('/foobar_group/subgroup', first=True)
+        results = self.kp.find_groups_by_path('/foobar_group/subgroup', first=True)
         self.assertEqual(results.name, 'subgroup')
 
     def test_groups(self):
-        results = self.pk.groups
+        results = self.kp.groups
 
         self.assertEqual(len(results), 4)
 
     #---------- Adding/Deleting Groups -----------
 
-    def test_add_group(self):
+    def test_add_delete_group(self):
         base_group_name = 'base_group'
         sub_group_name = 'sub_group'
-        base_group = self.pk.add_group(self.pk.root_group, base_group_name)
-        self.pk.add_group(base_group, sub_group_name)
+        base_group = self.kp.add_group(self.kp.root_group, base_group_name)
+        sub_group = self.kp.add_group(base_group, sub_group_name)
 
-        results = self.pk.find_groups_by_path(base_group_name + '/' + sub_group_name,
+        results = self.kp.find_groups_by_path(base_group_name + '/' + sub_group_name,
                                               first=True)
         self.assertIsInstance(results, Group)
         self.assertEqual(results.name, sub_group_name)
+
+        self.kp.delete_group(sub_group)
+        results = self.kp.find_groups_by_path(base_group_name + '/' + sub_group_name,
+                                              first=True)
+        self.assertIsNone(results)
 
 class EntryTests(unittest.TestCase):
 

--- a/pykeepass/tests.py
+++ b/pykeepass/tests.py
@@ -1,6 +1,8 @@
 import unittest
 import pykeepass
 import icons
+import shutil
+import os
 from group import Group
 from entry import Entry
 from datetime import datetime
@@ -17,11 +19,13 @@ Missing Tests:
 - Group object tests
 """
 
+base_dir = os.path.dirname(os.path.realpath(__file__))
+
 class EntryFunctionTests(unittest.TestCase):
 
     # get some things ready before testing
     def setUp(self):
-        self.kp = pykeepass.PyKeePass('./test.kdbx', password='passw0rd')
+        self.kp = pykeepass.PyKeePass(base_dir + '/test.kdbx', password='passw0rd')
 
     #---------- Finding entries -----------
 
@@ -95,7 +99,7 @@ class GroupFunctionTests(unittest.TestCase):
 
     # get some things ready before testing
     def setUp(self):
-        self.kp = pykeepass.PyKeePass('./test.kdbx', password='passw0rd')
+        self.kp = pykeepass.PyKeePass(base_dir + '/test.kdbx', password='passw0rd')
 
     #---------- Finding groups -----------
 
@@ -156,6 +160,24 @@ class EntryTests(unittest.TestCase):
         entry.set_custom_property('foo', 'bar')
         self.assertEqual(entry.get_custom_property('foo'), 'bar')
         self.assertIn('foo', entry.custom_properties)
+
+class PyKeePassTests(unittest.TestCase):
+    def setUp(self):
+        shutil.copy(base_dir + '/test.kdbx', base_dir + '/change_pass.kdbx')
+        self.kp = pykeepass.PyKeePass(base_dir + '/test.kdbx', password='passw0rd')
+        self.kp_pass = pykeepass.PyKeePass(base_dir + '/change_pass.kdbx', password='passw0rd')
+
+    def test_set_password(self):
+        self.kp_pass.set_password('f00bar')
+        self.kp_pass.save()
+        self.kp_pass = pykeepass.PyKeePass(base_dir + '/change_pass.kdbx', password='f00bar')
+
+        results = self.kp.find_entries_by_username('foobar_user', first=True)
+        self.assertEqual('foobar_user', results.username)
+
+
+    def tearDown(self):
+        os.remove(base_dir + '/change_pass.kdbx')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds support for setting the master password on the database.

This was taken from [add_credentials](https://github.com/libkeepass/libkeepass/blob/master/libkeepass/common.py#L178-L182) in libkeepass.

There is a potential issue, though.  It looks like libkeepass stores the hashed password (if it exists) and the hashed keyfile (if it exists) in kdb.keys.  If there's only one item in this list, I think it might be impossible to tell if it's a password or a keyfile hash.