### PR TITLE
Fix gibberish passwords when saving a second time

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -39,13 +39,14 @@ class PyKeePass(object):
         ).__enter__()
 
     def save(self, filename=None):
-        # FIXME The *second* save operations creates gibberish passwords
-        # FIXME the save operation should be moved to libkeepass at some point
-        #       we shouldn't need to open another fd here just to write
         if not filename:
             filename = self.kdb_filename
         with open(filename, 'wb+') as outfile:
+            # fix issue 43
+            # src.: https://github.com/pschmitt/pykeepass/issues/43
+            self.kdb.unprotect()
             self.kdb.write_to(outfile)
+            self.kdb._decrypt(outfile)
 
     # set the master password
     def set_password(self, password):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -88,6 +88,9 @@ class EntryFunctionTests(unittest.TestCase):
     def test_add_delete_entry(self):
         unique_str = 'test_add_entry_'
         expiry_time = datetime.now()
+
+        self.kp.save()
+
         entry = self.kp.add_entry(self.kp.root_group,
                                   unique_str + 'title',
                                   unique_str + 'user',
@@ -97,6 +100,9 @@ class EntryFunctionTests(unittest.TestCase):
                                   tags=unique_str + 'tags',
                                   expiry_time=expiry_time,
                                   icon=icons.KEY)
+
+        self.kp.save()
+
         results = self.kp.find_entries_by_title(unique_str + 'title')
         self.assertEqual(len(results), 1)
         results = self.kp.find_entries_by_title(unique_str + 'title', first=True)


### PR DESCRIPTION
This patch solves the problem described in the title (and described in the code as well).

As soon [this libkeepass PR is merged](https://github.com/libkeepass/libkeepass/pull/5), we will be able to go a bit further by relying only on the file descriptor opened by the `libkeepass` library. That way, we won't need to open a file descriptor by ourselves.