### PR TITLE
lxml Element have no Value field

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -69,7 +69,7 @@ class Entry(BaseElement):
     def _set_string_field(self, key, value):
         results = self._element.xpath('String/Key[text()="{}"]/..'.format(key))
         if results:
-            results[0].Value = value
+            results[0].text = value
         else:
             logger.debug('No field named {}. Create it.'.format(key))
             el = xmlfactory._create_string_element(key, value)


### PR DESCRIPTION
Creating an `Entry` manually then changing any of its field was failing with the following error message:

```
    results[0].Value = value
AttributeError: 'lxml.etree._Element' object has no attribute 'Value'
```

(only tested on Python 3 but I assume travis will do the job if it has tests for this use case).