### PR TITLE
fix dump_xml on python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 *.kdbx
 *.egg-info/
+*.xml

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -77,7 +77,7 @@ class PyKeePass(object):
         Dump the content of the database to a file
         NOTE The file is unencrypted!
         '''
-        with open(outfile, 'w+') as f:
+        with open(outfile, 'wb') as f:
             f.write(self.kdb.pretty_print())
 
     def _xpath(self, xpath_str, tree=None):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -226,6 +226,12 @@ class PyKeePassTests(unittest.TestCase):
         results = self.kp.find_entries_by_username('foobar_user', first=True)
         self.assertEqual('foobar_user', results.username)
 
+    def test_dump_xml(self):
+        self.kp.dump_xml('db_dump.xml')
+        with open('db_dump.xml') as f:
+            first_line = f.readline()
+            self.assertEqual(first_line, '<?xml version=\'1.0\' encoding=\'utf-8\' standalone=\'yes\'?>\n')
+
 
     def tearDown(self):
         os.remove(base_dir + '/change_creds.kdbx')


### PR DESCRIPTION
dump_xml returns bytes, so we need to add 'b' to file mode

```
Traceback (most recent call last):
  File "tests/tests.py", line 230, in test_dump_xml
    self.kp.dump_xml('db_dump')
  File "/home/evan/resources/pykeepass/pykeepass/pykeepass.py", line 81, in dump_xml
    f.write(self.kdb.pretty_print())
TypeError: write() argument must be str, not bytes
```