### PR TITLE
Make PyKeePass usable as a context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,13 @@ Simple Example
    # save database
    >>> kp.save()
 
+Context Manager Example
+--------------
+.. code:: python
+   >>> with PyKeePass('db.kdbx', password='somePassw0rd') as kp:
+      >>> entry = kp.find_entries(title='facebook', first=True)
+      >>> entry.password
+      's3cure_p455w0rd'
 
 Finding Entries
 ----------------------

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -27,6 +27,12 @@ class PyKeePass(object):
 
         self.read(password=password, keyfile=keyfile)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, typ, value, tb):
+        self.kdb.close()
+
     def read(self, filename=None, password=None, keyfile=None):
         self.password = password
         self.keyfile = keyfile

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -31,7 +31,7 @@ class PyKeePass(object):
         return self
 
     def __exit__(self, typ, value, tb):
-        self.kdb.close()
+        del self.kdbx
 
     def read(self, filename=None, password=None, keyfile=None):
         self.password = password

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -391,6 +391,12 @@ class PyKeePassTests(unittest.TestCase):
     def tearDown(self):
         os.remove(os.path.join(base_dir, 'change_creds.kdbx'))
 
+class CtxManagerTests(unittest.TestCase):
+    def test_ctx_manager(self):
+        with PyKeePass(os.path.join(base_dir, 'test.kdbx'), password='passw0rd', keyfile=base_dir + '/test.key') as kp:
+            results = kp.find_entries_by_username('foobar_user', first=True)
+            self.assertEqual('foobar_user', results.username)
+
 class KDBXTests(unittest.TestCase):
 
     def test_open_save(self):


### PR DESCRIPTION
A small patch so we can use `with` statements. Maybe it's no use to you if you're deprecating libkeepass /shrug