### PR TITLE
Set UUID when creating new group

### DIFF
--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -5,6 +5,8 @@ from lxml.etree import Element, _Element
 from lxml.objectify import ObjectifiedElement
 from lxml.builder import E
 import pykeepass.entry
+import base64
+import uuid
 
 
 class Group(BaseElement):
@@ -25,6 +27,9 @@ class Group(BaseElement):
         )
 
         if element is None:
+            self._element.append(
+                E.UUID(base64.b64encode(uuid.uuid1().bytes).decode('utf-8'))
+            )
             self._element.append(E.Name(name))
             if notes:
                 self._element.append(E.Notes(notes))


### PR DESCRIPTION
When a group is created it needs also a UUID. Because the group creation procedure isn't located in the BaseElement module we need to do the UUID creation in the Group module itself. This prevents creating groups without an UUID.