### PR TITLE
fix baseelement logic

### DIFF
--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -16,36 +16,31 @@ class BaseElement(object):
     def __init__(self, element=None, version=None, icon=None, expires=False,
                  expiry_time=None):
 
-        self._version = version
-        if element is None:
-            self._element = Element('Entry')
-            self._element.append(
-                E.UUID(base64.b64encode(uuid.uuid1().bytes).decode('utf-8'))
-            )
-            if icon:
-                self._element.append(E.IconID(icon))
-            current_time_str = self._encode_time(datetime.utcnow())
-            if expiry_time:
-                expiry_time_str = self._encode_time(
-                    self._datetime_to_utc(expiry_time)
-                )
-            else:
-                expiry_time_str = self._encode_time(datetime.utcnow())
-
-            self._element.append(
-                E.Times(
-                    E.CreationTime(current_time_str),
-                    E.LastModificationTime(current_time_str),
-                    E.LastAccessTime(current_time_str),
-                    E.ExpiryTime(expiry_time_str),
-                    E.Expires(str(expires if expires is not None else False)),
-                    E.UsageCount(str(0)),
-                    E.LocationChanged(current_time_str)
-                )
+        self._element = element
+        self._element.append(
+            E.UUID(base64.b64encode(uuid.uuid1().bytes).decode('utf-8'))
+        )
+        if icon:
+            self._element.append(E.IconID(icon))
+        current_time_str = self._encode_time(datetime.utcnow())
+        if expiry_time:
+            expiry_time_str = self._encode_time(
+                self._datetime_to_utc(expiry_time)
             )
         else:
-            self._element = element
+            expiry_time_str = self._encode_time(datetime.utcnow())
 
+        self._element.append(
+            E.Times(
+                E.CreationTime(current_time_str),
+                E.LastModificationTime(current_time_str),
+                E.LastAccessTime(current_time_str),
+                E.ExpiryTime(expiry_time_str),
+                E.Expires(str(expires if expires is not None else False)),
+                E.UsageCount(str(0)),
+                E.LocationChanged(current_time_str)
+            )
+        )
 
     def _get_subelement_text(self, tag):
         v = self._element.find(tag)

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -31,16 +31,16 @@ class Entry(BaseElement):
         assert type(version) is tuple, 'The provided version is not a tuple, but a {}'.format(
             type(version)
         )
-
-        super(Entry, self).__init__(
-            element=element,
-            version=version,
-            expires=expires,
-            expiry_time=expiry_time,
-            icon=icon
-        )
+        self._version = version
 
         if element is None:
+            super(Entry, self).__init__(
+                element=Element('Entry'),
+                version=version,
+                expires=expires,
+                expiry_time=expiry_time,
+                icon=icon
+            )
             self._element.append(E.String(E.Key('Title'), E.Value(title)))
             self._element.append(E.String(E.Key('UserName'), E.Value(username)))
             self._element.append(
@@ -62,6 +62,7 @@ class Entry(BaseElement):
                 )
             assert element.tag == 'Entry', 'The provided element is not an Entry '\
                 'element, but a {}'.format(element.tag)
+            self._element = element
 
     def _get_string_field(self, key):
         results = self._element.xpath('String/Key[text()="{}"]/../Value'.format(key))

--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -15,16 +15,17 @@ class Group(BaseElement):
         assert type(version) is tuple, 'The provided version is not a tuple, but a {}'.format(
             type(version)
         )
+        self._version = version
 
-        super(Group, self).__init__(
-            element=Element('Group') if element is None else element,
-            version=version,
-            expires=expires,
-            expiry_time=expiry_time,
-            icon=icon
-        )
 
         if element is None:
+            super(Group, self).__init__(
+                element=Element('Group'),
+                version=version,
+                expires=expires,
+                expiry_time=expiry_time,
+                icon=icon
+            )
             self._element.append(E.Name(name))
             if notes:
                 self._element.append(E.Notes(notes))
@@ -36,7 +37,6 @@ class Group(BaseElement):
                 )
             assert element.tag == 'Group', 'The provided element is not a Group '\
                 'element, but a {}'.format(element.tag)
-
             self._element = element
 
     @property


### PR DESCRIPTION
Changed it so that `BaseElement.__init__` is only called when `element` is None in `Group` and `Entry`.