### PR TITLE
Decryption: Strip out not allowed characters

### DIFF
--- a/pykeepass/kdbx_parsing/common.py
+++ b/pykeepass/kdbx_parsing/common.py
@@ -9,6 +9,7 @@ from construct import (
 )
 from lxml import etree
 import base64
+import unicodedata
 import zlib
 from io import BytesIO
 from collections import OrderedDict
@@ -153,11 +154,11 @@ class UnprotectedStream(Adapter):
         cipher = self.get_cipher(self.protected_stream_key(con))
         for elem in tree.xpath(self.protected_xpath):
             if elem.text is not None:
-                elem.text = cipher.decrypt(
+                elem.text = ''.join(c for c in cipher.decrypt(
                     base64.b64decode(
                         elem.text
                     )
-                ).decode('utf-8')
+                ).decode('utf-8') if unicodedata.category(c)[0] != "C")
             elem.attrib['Protected'] = 'False'
         return tree
 


### PR DESCRIPTION
On decryption we don't really know in which codeset we're receiving strings, that can lead to a problem with the LXML parser. Right now we assumed that we receive only UTF-8 strings, the decryption to UTF-8 can convert non UTF-8 characters but is not able remove invalid ones like control characters. This means they remain. This leads to an invalid XML and therefore LXML would throw an ValueError exception when it receives such an invalid string.
To prevent this from happening it is needed that we remove those invalid characters.
You can try this out with the following string (I hope GitHub doesn't manipulate it): `��`
Downstream bug: https://gitlab.gnome.org/World/PasswordSafe/issues/36

This manipulation would also be necessary when encoding. Because a user is also able to use for example the above string for an entry property etc. and this would also led to an exception. But I have not done this yet.
