### PR TITLE
fix "object has no attribute" issue in save_history

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -255,9 +255,10 @@ class Entry(BaseElement):
         Save the entry in its history
         '''
         archive = deepcopy(self._element)
-        if self._element.find('History') is not None:
-            archive.remove(archive.History)
-            self._element.History.append(archive)
+        hist = archive.find('History')
+        if hist is not None:
+            archive.remove(hist)
+            self._element.find('History').append(archive)
         else:
             history = Element('History')
             history.append(archive)


### PR DESCRIPTION
Not sure if this is the right way to fix this issue but it solved my problem with python2 and python3. maybe there's a way to tell lxml to create the attributes when loading the file.