### PR TITLE
Fix datetime comparison when there is no tzinfo and autotype sequence none check

### DIFF
--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -78,7 +78,7 @@ class BaseElement(object):
 
     def _datetime_to_utc(self, dt):
         """Convert naive datetimes to UTC"""
-        
+
         if not dt.tzinfo:
             dt = dt.replace(tzinfo=tz.gettz())
         return dt.astimezone(tz.gettz('UTC'))
@@ -150,7 +150,9 @@ class BaseElement(object):
 
     @property
     def expired(self):
-        return self.expires and (datetime.utcnow() > self.expiry_time)
+        if self.expires:
+            return self._datetime_to_utc(datetime.utcnow()) > self._datetime_to_utc(self.expiry_time)
+        return False
 
 
     @property

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -177,7 +177,8 @@ class Entry(BaseElement):
 
     @property
     def autotype_sequence(self):
-        return self._element.find('AutoType/DefaultSequence').text
+        sequence = self._element.find('AutoType/DefaultSequence')
+        return sequence.text if sequence else None
 
     @autotype_sequence.setter
     def autotype_sequence(self, value):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pykeepass",
-    version="3.0.2",
+    version="3.0.3",
     license="GPL3",
     description="Python library to interact with keepass databases "
                 "(supports KDBX3 and KDBX4)",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pykeepass",
-    version="3.0.3",
+    version="3.0.2",
     license="GPL3",
     description="Python library to interact with keepass databases "
                 "(supports KDBX3 and KDBX4)",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,6 +4,7 @@ from pykeepass import icons, PyKeePass
 from pykeepass.entry import Entry
 from pykeepass.group import Group
 from pykeepass.kdbx_parsing import KDBX
+from lxml.etree import Element
 import os
 import shutil
 import unittest
@@ -349,6 +350,7 @@ class EntryTests(unittest.TestCase):
     def test_expired_datetime_offset(self):
         """Test for https://github.com/pschmitt/pykeepass/issues/115"""
         future_time = datetime.now() + timedelta(days=1)
+        past_time = datetime.now() - timedelta(days=1)
         entry = Entry(
             'title',
             'username',
@@ -358,6 +360,21 @@ class EntryTests(unittest.TestCase):
             version=self.kp.version
         )
         self.assertFalse(entry.expired)
+
+        entry.expiry_time = past_time
+        self.assertTrue(entry.expired)
+
+    def test_autotype_no_default_sequence(self):
+        entry = Entry(
+            'title',
+            'username',
+            'password',
+            # create an element, but one without AuthType
+            element=Element('Entry'),
+            version=self.kp.version
+        )
+        self.assertIsNone(entry.autotype_sequence)
+
 
 class GroupTests(unittest.TestCase):
     # get some things ready before testing

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -346,6 +346,19 @@ class EntryTests(unittest.TestCase):
         entry.tags = ['changed', 'again', 'tags']
         self.assertEqual(entry.tags, ['changed', 'again', 'tags'])
 
+    def test_expired_datetime_offset(self):
+        """Test for https://github.com/pschmitt/pykeepass/issues/115"""
+        future_time = datetime.now() + timedelta(days=1)
+        entry = Entry(
+            'title',
+            'username',
+            'password',
+            expires=True,
+            expiry_time=future_time,
+            version=self.kp.version
+        )
+        self.assertFalse(entry.expired)
+
 class GroupTests(unittest.TestCase):
     # get some things ready before testing
     def setUp(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -369,7 +369,7 @@ class EntryTests(unittest.TestCase):
             'title',
             'username',
             'password',
-            # create an element, but one without AuthType
+            # create an element, but one without AutoType
             element=Element('Entry'),
             version=self.kp.version
         )


### PR DESCRIPTION
Resolves issues: https://github.com/pschmitt/pykeepass/issues/115 and https://github.com/pschmitt/pykeepass/issues/117