### PR TITLE
Autotype property fix

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -195,7 +195,7 @@ class Entry(BaseElement):
     def autotype_enabled(self, value):
         enabled = self._element.find('AutoType/Enabled')
         if value is not None:
-            enabled.text= str(value)
+            enabled.text = str(value)
         else:
             enabled.text = None
 

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -202,7 +202,7 @@ class Entry(BaseElement):
     @property
     def autotype_sequence(self):
         sequence = self._element.find('AutoType/DefaultSequence')
-        return sequence.text if sequence else None
+        return sequence.text if sequence is not None else None
 
     @autotype_sequence.setter
     def autotype_sequence(self, value):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,6 +110,7 @@ class EntryFindTests3(KDBX3Tests):
     def test_find_entries_by_autotype_sequence(self):
         results = self.kp.find_entries(autotype_sequence='{TAB}', regex=True)
         self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].autotype_sequence, '{USERNAME}{TAB}{PASSWORD}{ENTER}')
 
     def test_find_entries_by_autotype_enabled(self):
         results = self.kp.find_entries(autotype_enabled=True)


### PR DESCRIPTION
The property `autotype_sequence` was not returning a value when a value was clearly visible using dump_xml() or viewing the autotype sequence in KeepassXC. This PR should fix that problem. All tests still pass. Included one small related PEP8 fix as well. Thanks!