### PR TITLE
zero-index attachment id

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,10 @@ string representing this attachment
 
 the data that this attachment points to.  Raises ``AttachmentError`` if data does not exist.
 
+**Attachment.entry**
+
+the entry that this attachment is attached to
+
 .. code:: python
 
    >>> e = kp.add_entry(kp.root_group, title='foo', username='', password='')

--- a/pykeepass/attachment.py
+++ b/pykeepass/attachment.py
@@ -41,11 +41,13 @@ class Attachment(object):
         return pykeepass.entry.Entry(element=ancestor, kp=self._kp)
 
     @property
-    def data(self):
+    def binary(self):
         try:
             return self._kp.binaries[self.id]
         except IndexError:
             raise BinaryError('No such binary with id {}'.format(self.id))
+
+    data = binary
 
     def delete(self):
         self._element.getparent().remove(self._element)

--- a/pykeepass/attachment.py
+++ b/pykeepass/attachment.py
@@ -7,6 +7,8 @@ from future.utils import python_2_unicode_compatible
 import pykeepass.entry
 from collections import namedtuple
 
+from pykeepass.exceptions import BinaryError
+
 # FIXME python2
 @python_2_unicode_compatible
 class Attachment(object):
@@ -43,7 +45,7 @@ class Attachment(object):
         try:
             return self._kp.binaries[self.id]
         except IndexError:
-            raise AttachmentError('No such attachment id')
+            raise BinaryError('No such binary with id {}'.format(self.id))
 
     def delete(self):
         self._element.getparent().remove(self._element)

--- a/pykeepass/exceptions.py
+++ b/pykeepass/exceptions.py
@@ -1,7 +1,7 @@
 # ----- binary parsing exceptions -----
 
 # ----- pykeepass exceptions -----
-class AttachmentError(Exception):
+class BinaryError(Exception):
     pass
 
 # ----- Entry exceptions -----

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -513,7 +513,7 @@ class PyKeePass(object):
                 binaries = self._xpath('/KeePassFile/Meta/Binaries', first=True)
                 binaries.remove(binaries.getchildren()[id])
         except IndexError:
-            raise AttachmentError('No such attachment with id {}'.format(id))
+            raise BinaryError('No such binary with id {}'.format(id))
 
         # remove all entry references to this attachment
         for reference in self.find_attachments(id=id):

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -501,7 +501,7 @@ class PyKeePass(object):
             )
 
         # return attachment id
-        return len(self.binaries)
+        return len(self.binaries) - 1
 
     def delete_binary(self, id):
         try:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,6 +9,7 @@ from pykeepass import icons, PyKeePass
 from pykeepass.entry import Entry
 from pykeepass.group import Group
 from pykeepass.kdbx_parsing import KDBX
+from pykeepass.exceptions import BinaryError
 from lxml.etree import Element
 import os
 import shutil
@@ -431,14 +432,21 @@ class AttachmentTests3(KDBX3Tests):
             keyfile=os.path.join(base_dir, self.keyfile)
         )
 
-    def test_create_delete_attachment(self):
+    def test_create_delete_binary(self):
+        with self.assertRaises(BinaryError):
+            self.kp.delete_binary(999)
+        with self.assertRaises(BinaryError):
+            e = self.kp.entries[0]
+            e.add_attachment(filename='foo.txt', id=123)
+            e.attachments[0].data
+
         binary_id = self.kp.add_binary(b'Ronald McDonald Trump')
         self.kp.save()
         self.open()
         self.assertEqual(self.kp.binaries[binary_id], b'Ronald McDonald Trump')
 
         num_attach = len(self.kp.binaries)
-        self.kp.delete_binary(len(self.kp.binaries) - 1)
+        self.kp.delete_binary(binary_id)
         self.kp.save()
         self.open()
         self.assertEqual(len(self.kp.binaries), num_attach - 1)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -438,7 +438,7 @@ class AttachmentTests3(KDBX3Tests):
         with self.assertRaises(BinaryError):
             e = self.kp.entries[0]
             e.add_attachment(filename='foo.txt', id=123)
-            e.attachments[0].data
+            e.attachments[0].binary
 
         binary_id = self.kp.add_binary(b'Ronald McDonald Trump')
         self.kp.save()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -432,10 +432,10 @@ class AttachmentTests3(KDBX3Tests):
         )
 
     def test_create_delete_attachment(self):
-        attachment_id = self.kp.add_binary(b'Ronald McDonald Trump')
+        binary_id = self.kp.add_binary(b'Ronald McDonald Trump')
         self.kp.save()
         self.open()
-        self.assertEqual(self.kp.binaries[-1], b'Ronald McDonald Trump')
+        self.assertEqual(self.kp.binaries[binary_id], b'Ronald McDonald Trump')
 
         num_attach = len(self.kp.binaries)
         self.kp.delete_binary(len(self.kp.binaries) - 1)
@@ -458,7 +458,6 @@ class AttachmentTests3(KDBX3Tests):
 
     def tearDown(self):
         os.remove(os.path.join(base_dir, 'test_attachment.kdbx'))
-
 
 
 class PyKeePassTests3(KDBX3Tests):


### PR DESCRIPTION
- `kp.add_attachment` is now zero indexed so that it can be used directly in `kp.binaries`
- add missing function documentation for `Attachment.entry`
- rename `AttachmentError` to `BinaryError` and fix broken import. add test
- alias `Attachment.binary` to `Attachment.data`