### PR TITLE
Fix/attachments

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -492,7 +492,14 @@ class PyKeePass(object):
             )
             if compressed:
                 # gzip compression
-                data = zlib.compress(data)
+                compressobj = zlib.compressobj(
+                    6,
+                    zlib.DEFLATED,
+                    16 + 15,
+                    zlib.DEF_MEM_LEVEL,
+                    0
+                )
+                data = compressobj.compress(data) + compressobj.flush()
             data = base64.b64encode(data).decode
 
             # add binary element to XML

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -454,7 +454,7 @@ class PyKeePass(object):
 
     @property
     def attachments(self):
-        self.find_attachments(filename='.*', regex=True)
+        return self.find_attachments(filename='.*', regex=True)
 
     @property
     def binaries(self):


### PR DESCRIPTION
Fixes some keepass2 GUI attachments interoperabilities:
- ~~missing ID attribute in *KeePassFile/Meta/Binaries/Binary* tags (kdbx version <4.0)~~
- ~~`kp.add_binary` returned wrong id~~
- adding missing gzip header on attachment compression